### PR TITLE
Fixed BepInEx Download 

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -28,7 +28,7 @@
     "version": "5.4.23",
     "git_path": "BepInEx/BepInEx",
     "group": "Core",
-    "download_url": "https://github.com/BepInEx/BepInEx/releases/download/v5.4.23/BepInEx_linux_x86_5.4.23.0.zip"
+    "download_url": "https://github.com/BepInEx/BepInEx/releases/download/v5.4.23/BepInEx_win_x64_5.4.23.0.zip"
   },
   {
     "name": "Bepinject",

--- a/mods.json
+++ b/mods.json
@@ -3,7 +3,7 @@
 			"name": "BepInEx",
 			"tag": "",
 			"gitPath": "BepInEx/BepInEx",
-			"releaseId": 1,
+			"releaseId": 4,
 			"author": "BepInEx Team",
 			"group": "Core"
 		},


### PR DESCRIPTION
Fixed MonkeModManager installing the Linux version of BepInEx instead of x64 by updating the release id. Note if the order of the assets change in the next release of BepInEx (which is probably wont) it will break again. I've never made a pull request before so if this somehow breaks everything good luck fixing it :P